### PR TITLE
fix: show error for an empty file

### DIFF
--- a/tichy.py
+++ b/tichy.py
@@ -530,6 +530,12 @@ def send_file(ex_number, plik):
     br.select_form(nr=0)
     with open(plik, 'r') as file:
         data = file.read()
+    if data == "":
+        if lang == "pl":
+            print(colored(f"Nie wysłano, plik jest pusty", 'red', attrs=['bold']))
+        else:
+            print(colored(f"Failed to sent, file is empty", 'red', attrs=['bold']))
+        return
     answer = br.form.find_control("src")
     answer.value = str(data)
     br.submit()


### PR DESCRIPTION
Tak wygląda zawartość terminala po próbie wysłania pustego pliku
```sh
Exercise number: 3
[  ]Opening exercise Dyżury...
[OK]Successfully opened exercise Dyżury.
[  ]Sending answer of exercise Dyżury...
[OK]Sent.
[  ]Waiting for results...
Traceback (most recent call last):
  File "D:\algorytmy\tichy.py", line 810, in <module>
    send_file(ex_nr, args[2])
  File "D:\algorytmy\tichy.py", line 552, in send_file
    for tr in soup.find(id='results_table').find('tbody').findAll('tr'):
AttributeError: 'NoneType' object has no attribute 'find'
```

Jeżeli `textarea` jest pusta na stronie to przycisk `Wyślij` nie wysyła rozwiązania, dlatego w terminalu nie powinno pojawić się
`[OK] Sent.`
